### PR TITLE
Add AI messaging intelligence and health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,26 @@ Deploy xong Vercel cấp domain: `https://<project>.vercel.app`
 - Vào **Vercel → Project → Settings → Environment Variables**: dán token vào `FB_PAGE_ACCESS_TOKEN` → **Save** → **Redeploy** (hoặc **Deploy** lại)
 
 ### 4) Test
-- Dùng tài khoản admin/dev/tester nhắn tin vào **Page** → bot sẽ **echo** lại.
+- Dùng tài khoản admin/dev/tester nhắn tin vào **Page** → bot sẽ tự động chào nếu bạn nói "hello", hoặc dùng AI để trả lời thông minh hơn.
+
+## Luồng xử lý tin nhắn
+1. Meta gửi webhook POST tới `/api/webhook`.
+2. Server đọc từng `entry.messaging` event và chuyển vào `processMessagingEvent`.
+3. Hàm xử lý sẽ:
+   - Bỏ qua tin nhắn echo, validate sender.
+   - Kiểm tra nội dung "hello" để trả lời nhanh.
+   - Nếu có text khác, gọi OpenAI (nếu cấu hình) để sinh câu trả lời.
+   - Nếu là hình ảnh/tệp, gửi thông báo đã nhận tệp để tránh crash.
+   - Ghi log vào Google Sheets (nếu cấu hình) và gửi phản hồi qua Graph API.
+4. Để tránh timeout khi deploy trên Vercel, từng bước được bao trong timeout 8s và xử lý song song.
+
+## Endpoint mới
+- `GET /api/health` trả về `{ "status": "ok" }` giúp kiểm tra bot đang chạy.
+
+## Environment variables bổ sung
+- `OPENAI_API_KEY` và `OPENAI_MODEL` (tuỳ chọn, mặc định `gpt-4o-mini`).
+- `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`, `GOOGLE_SHEETS_SPREADSHEET_ID`, `GOOGLE_SHEETS_WORKSHEET_NAME` (tuỳ chọn) để log tin nhắn.
+- `DEFAULT_FALLBACK_MESSAGE` để tuỳ biến câu trả lời mặc định.
 
 ## Ghi chú
 - Serverless có thể "lạnh" lần đầu, nhưng Vercel sẽ tự chạy khi có request.

--- a/api/health.js
+++ b/api/health.js
@@ -1,0 +1,4 @@
+export default function handler(req, res) {
+  return res.status(200).json({ status: "ok" });
+}
+

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,15 +1,64 @@
-// api/webhook.js
-// Vercel Serverless Function (Node 18+). Dùng cho Facebook Messenger Webhook.
+import { buildDependencies, processMessagingEvent } from "../lib/messageProcessor.js";
+import { createSmartReplyGenerator } from "../lib/openAIResponder.js";
+import { createSheetsLogger } from "../lib/googleSheetsLogger.js";
+import { createFacebookSender } from "../lib/facebookMessenger.js";
+import { withTimeout } from "../lib/withTimeout.js";
+
+const DEFAULT_TIMEOUT_MS = 8000;
+
+function createDependenciesFromEnv() {
+  const sendTextMessage = createFacebookSender({
+    pageToken: process.env.FB_PAGE_ACCESS_TOKEN,
+    graphVersion: process.env.FB_GRAPH_VERSION,
+  });
+
+  const generateSmartReply = createSmartReplyGenerator({
+    apiKey: process.env.OPENAI_API_KEY,
+    model: process.env.OPENAI_MODEL,
+  });
+
+  const logMessage = createSheetsLogger({
+    clientEmail: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
+    privateKey: process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY,
+    spreadsheetId: process.env.GOOGLE_SHEETS_SPREADSHEET_ID,
+    worksheetName: process.env.GOOGLE_SHEETS_WORKSHEET_NAME,
+  });
+
+  return buildDependencies({
+    sendTextMessage,
+    generateSmartReply,
+    logMessage,
+    fallbackMessage: process.env.DEFAULT_FALLBACK_MESSAGE || "Cảm ơn bạn! Chúng tôi sẽ phản hồi sớm nhất.",
+  });
+}
+
+async function handleEvents(entries, deps) {
+  const tasks = [];
+
+  for (const entry of entries) {
+    const events = entry.messaging || [];
+    for (const event of events) {
+      tasks.push(
+        withTimeout(
+          processMessagingEvent(event, deps),
+          DEFAULT_TIMEOUT_MS,
+          () => console.warn("Processing event timed out", { sender: event?.sender?.id })
+        ).catch((err) => {
+          console.error("Process message error", err);
+        })
+      );
+    }
+  }
+
+  await Promise.allSettled(tasks);
+}
 
 export default async function handler(req, res) {
-  const VERIFY_TOKEN  = process.env.FB_VERIFY_TOKEN;         // bạn tự đặt
-  const PAGE_TOKEN    = process.env.FB_PAGE_ACCESS_TOKEN || ""; // token của Page
-  const GRAPH_VERSION = process.env.FB_GRAPH_VERSION || "v21.0";
+  const VERIFY_TOKEN = process.env.FB_VERIFY_TOKEN;
 
-  // 1) VERIFY: Facebook gọi GET để xác minh webhook
   if (req.method === "GET") {
-    const mode      = req.query["hub.mode"];
-    const token     = req.query["hub.verify_token"];
+    const mode = req.query["hub.mode"];
+    const token = req.query["hub.verify_token"];
     const challenge = req.query["hub.challenge"];
 
     if (mode === "subscribe" && token === VERIFY_TOKEN) {
@@ -18,37 +67,18 @@ export default async function handler(req, res) {
     return res.status(403).send("Forbidden");
   }
 
-  // 2) EVENTS: Facebook đẩy POST khi có tin nhắn vào Page
   if (req.method === "POST") {
     try {
-      const body    = req.body || {};
+      const body = req.body || {};
       const entries = body.entry || [];
 
-      for (const entry of entries) {
-        const events = entry.messaging || [];
-        for (const ev of events) {
-          const senderId = ev?.sender?.id;
-          const msgText  = ev?.message?.text;
-
-          // Ghi log để debug trên Vercel (Deployments → Functions → Logs)
-          console.log("Incoming:", JSON.stringify(ev));
-
-          // Trả lời ECHO rất đơn giản
-          if (senderId && msgText && PAGE_TOKEN) {
-            const url = `https://graph.facebook.com/${GRAPH_VERSION}/me/messages?access_token=${encodeURIComponent(PAGE_TOKEN)}`;
-            await fetch(url, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                recipient: { id: senderId },
-                message:   { text: `Xin chào! Bạn vừa nói: "${msgText}"` }
-              })
-            });
-          }
-        }
+      if (!Array.isArray(entries) || entries.length === 0) {
+        return res.status(200).send("EVENT_RECEIVED");
       }
 
-      // Luôn trả 200 để Facebook không retry quá mức
+      const deps = createDependenciesFromEnv();
+      await handleEvents(entries, deps);
+
       return res.status(200).send("EVENT_RECEIVED");
     } catch (err) {
       console.error("Webhook error:", err);
@@ -56,7 +86,6 @@ export default async function handler(req, res) {
     }
   }
 
-  // 3) Phương thức khác
   return res.status(405).send("Method Not Allowed");
 }
 

--- a/lib/facebookMessenger.js
+++ b/lib/facebookMessenger.js
@@ -1,0 +1,27 @@
+const DEFAULT_GRAPH_VERSION = "v21.0";
+
+export function createFacebookSender({ pageToken, graphVersion = DEFAULT_GRAPH_VERSION } = {}) {
+  if (!pageToken) {
+    return async () => {
+      throw new Error("Missing Facebook PAGE access token");
+    };
+  }
+
+  const baseUrl = `https://graph.facebook.com/${graphVersion}/me/messages?access_token=${encodeURIComponent(pageToken)}`;
+
+  return async function sendTextMessage(recipientId, text) {
+    if (!recipientId || !text) {
+      return;
+    }
+
+    await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        recipient: { id: recipientId },
+        message: { text },
+      }),
+    });
+  };
+}
+

--- a/lib/googleSheetsLogger.js
+++ b/lib/googleSheetsLogger.js
@@ -1,0 +1,44 @@
+import { google } from "googleapis";
+
+function normalizePrivateKey(key) {
+  return key?.replace(/\\n/g, "\n");
+}
+
+export function createSheetsLogger({
+  clientEmail,
+  privateKey,
+  spreadsheetId,
+  worksheetName = "Sheet1",
+} = {}) {
+  if (!clientEmail || !privateKey || !spreadsheetId) {
+    return async () => false;
+  }
+
+  const auth = new google.auth.JWT({
+    email: clientEmail,
+    key: normalizePrivateKey(privateKey),
+    scopes: ["https://www.googleapis.com/auth/spreadsheets"],
+  });
+
+  const sheets = google.sheets({ version: "v4", auth });
+
+  return async function logMessage({ timestamp, senderId, text, hasAttachments, reply }) {
+    const values = [[
+      timestamp,
+      senderId || "",
+      text || (hasAttachments ? "[Attachments]" : ""),
+      hasAttachments ? "Yes" : "No",
+      reply || "",
+    ]];
+
+    await sheets.spreadsheets.values.append({
+      spreadsheetId,
+      range: `${worksheetName}!A:E`,
+      valueInputOption: "USER_ENTERED",
+      requestBody: { values },
+    });
+
+    return true;
+  };
+}
+

--- a/lib/messageProcessor.js
+++ b/lib/messageProcessor.js
@@ -1,0 +1,108 @@
+const HELLO_REGEX = /\bhello\b/i;
+
+function normalizeText(text) {
+  return typeof text === "string" ? text.trim() : "";
+}
+
+function attachmentsSummary(attachments = []) {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
+    return null;
+  }
+  const types = attachments
+    .map((att) => att?.type)
+    .filter(Boolean)
+    .map((type) => type.toLowerCase());
+  if (types.length === 0) {
+    return `tệp đính kèm`;
+  }
+  const unique = [...new Set(types)];
+  return unique.length === 1
+    ? `tệp ${unique[0]}`
+    : `tệp (${unique.join(", ")})`;
+}
+
+export async function processMessagingEvent(event, deps) {
+  const {
+    sendTextMessage,
+    generateSmartReply,
+    logMessage,
+    fallbackMessage = "Xin cảm ơn bạn đã liên hệ!",
+  } = deps || {};
+
+  const senderId = event?.sender?.id;
+  const message = event?.message;
+
+  if (!senderId || !message || message?.is_echo) {
+    return {
+      handled: false,
+      reason: !senderId ? "missing_sender" : message?.is_echo ? "echo" : "missing_message",
+    };
+  }
+
+  const text = normalizeText(message.text);
+  const hasText = Boolean(text);
+  const hasAttachments = Array.isArray(message.attachments) && message.attachments.length > 0;
+
+  const now = new Date();
+  const logPayload = {
+    timestamp: now.toISOString(),
+    senderId,
+    text: hasText ? text : null,
+    hasAttachments,
+  };
+
+  let replyText = null;
+
+  if (hasText && HELLO_REGEX.test(text)) {
+    replyText = "Xin chào! Mình có thể giúp gì cho bạn hôm nay?";
+  } else if (hasText) {
+    try {
+      replyText = (await generateSmartReply?.(text, { senderId }))?.trim();
+    } catch (err) {
+      console.error("OpenAI reply error", err);
+    }
+  }
+
+  if (!replyText && hasAttachments) {
+    const summary = attachmentsSummary(message.attachments);
+    replyText = `Mình đã nhận được ${summary || "tệp"} của bạn. Bạn có thể cho mình biết thêm chi tiết không?`;
+  }
+
+  if (!replyText) {
+    replyText = fallbackMessage;
+  }
+
+  if (typeof sendTextMessage === "function") {
+    await sendTextMessage(senderId, replyText);
+  }
+
+  if (typeof logMessage === "function") {
+    try {
+      await logMessage({
+        ...logPayload,
+        reply: replyText,
+      });
+    } catch (err) {
+      console.error("Log message error", err);
+    }
+  }
+
+  return { handled: true, replyText };
+}
+
+export function buildDependencies(options = {}) {
+  const {
+    sendTextMessage,
+    generateSmartReply,
+    logMessage,
+    fallbackMessage,
+  } = options;
+
+  return {
+    sendTextMessage,
+    generateSmartReply,
+    logMessage,
+    fallbackMessage,
+  };
+}
+

--- a/lib/openAIResponder.js
+++ b/lib/openAIResponder.js
@@ -1,0 +1,51 @@
+import OpenAI from "openai";
+
+let client;
+
+function getClient(apiKey) {
+  if (!apiKey) {
+    return null;
+  }
+  if (!client) {
+    client = new OpenAI({ apiKey });
+  }
+  return client;
+}
+
+export function createSmartReplyGenerator({
+  apiKey,
+  model = "gpt-4o-mini",
+  systemPrompt = "Bạn là trợ lý thân thiện của một trang Facebook, luôn trả lời ngắn gọn và hữu ích bằng tiếng Việt.",
+  maxTokens = 200,
+  temperature = 0.7,
+} = {}) {
+  const openai = getClient(apiKey);
+
+  if (!openai) {
+    return async () => null;
+  }
+
+  return async function generateSmartReply(message, context = {}) {
+    const messages = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: message },
+    ];
+
+    if (context?.senderId) {
+      messages.push({
+        role: "system",
+        content: `ID người dùng Facebook: ${context.senderId}`,
+      });
+    }
+
+    const completion = await openai.chat.completions.create({
+      model,
+      messages,
+      temperature,
+      max_tokens: maxTokens,
+    });
+
+    return completion?.choices?.[0]?.message?.content ?? null;
+  };
+}
+

--- a/lib/withTimeout.js
+++ b/lib/withTimeout.js
@@ -1,0 +1,22 @@
+export async function withTimeout(promise, ms, onTimeout) {
+  let timeoutId;
+  const timeoutPromise = new Promise((resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      if (typeof onTimeout === "function") {
+        try {
+          onTimeout();
+        } catch (err) {
+          console.error("Timeout handler error", err);
+        }
+      }
+      reject(new Error(`Operation timed out after ${ms}ms`));
+    }, ms);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -3,5 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "engines": { "node": ">=18" }
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "googleapis": "^129.0.0",
+    "openai": "^4.57.0"
+  }
 }

--- a/tests/messageProcessor.test.js
+++ b/tests/messageProcessor.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { processMessagingEvent } from "../lib/messageProcessor.js";
+
+function buildEvent({ senderId = "123", text, attachments } = {}) {
+  return {
+    sender: { id: senderId },
+    message: {
+      text,
+      attachments,
+    },
+  };
+}
+
+test("responds with hello template when user says hello", async () => {
+  const messages = [];
+  const event = buildEvent({ text: "hello there" });
+
+  const result = await processMessagingEvent(event, {
+    sendTextMessage: async (id, text) => messages.push({ id, text }),
+  });
+
+  assert.equal(result.replyText.includes("Xin chào"), true);
+  assert.equal(messages[0].text, result.replyText);
+});
+
+test("uses smart reply when available", async () => {
+  const event = buildEvent({ text: "Tell me a joke" });
+  const result = await processMessagingEvent(event, {
+    sendTextMessage: async () => {},
+    generateSmartReply: async () => "Here is a joke",
+  });
+
+  assert.equal(result.replyText, "Here is a joke");
+});
+
+test("handles attachments without crashing", async () => {
+  const event = buildEvent({ text: "", attachments: [{ type: "image" }] });
+  const result = await processMessagingEvent(event, {
+    sendTextMessage: async () => {},
+  });
+
+  assert.ok(result.replyText.includes("tệp"));
+});
+
+test("falls back gracefully when sender missing", async () => {
+  const result = await processMessagingEvent({}, {});
+  assert.equal(result.handled, false);
+});
+


### PR DESCRIPTION
## Summary
- refactor webhook handling to delegate to a reusable message processor with timeout protection
- integrate OpenAI-powered replies, Google Sheets logging, and automatic "hello" greeting
- add a health check endpoint and documentation for new environment variables and flow
- create unit tests for the message processor logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d6ae65dda0832892a66e7a2ec4cab6